### PR TITLE
Disable envFrom

### DIFF
--- a/charts/settle-server/templates/sidekiq-deployment.yaml
+++ b/charts/settle-server/templates/sidekiq-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         command: ["bundle", "exec", "sidekiq"]
-        envFrom:
-          - configMapRef:
-              name: {{ .Values.sidekiq.configMap }}
+        # envFrom:
+        #   - configMapRef:
+        #       name: {{ .Values.sidekiq.configMap }}
 {{- end }}


### PR DESCRIPTION
To address error:
`The Deployment "sidekiq" is invalid: spec.template.spec.containers[0].envFrom[0].configMapRef.name: Required value`